### PR TITLE
Fix "Connecting..." message being stuck once plugin connects.

### DIFF
--- a/UltraVibrations/Services/ButtplugService.cs
+++ b/UltraVibrations/Services/ButtplugService.cs
@@ -153,6 +153,8 @@ public class ButtplugService : IDisposable
                 return;
             }
 
+            statusMessage = null;
+
             Plugin.Log.Debug("Connected. Triggering scan.");
             OnRequestedScan?.Invoke(this, EventArgs.Empty);
         }


### PR DESCRIPTION
The connection message was getting stuck on "Connecting..." even when the plugin connected because the `statusMessage` wasn't getting unset.